### PR TITLE
[Fix] Patched RCE arising inside the "launchpad" library

### DIFF
--- a/lib/local/instance.js
+++ b/lib/local/instance.js
@@ -104,7 +104,7 @@ Instance.prototype.stop = function (callback) {
       execFile(command[0], command.slice(1));
     } else if (process.platform === 'win32') {
       //Adding `"` wasn't safe/functional on Win systems
-      command = 'taskkill /IM ' + (this.options.imageName || path.basename(this.cmd); 
+      command = 'taskkill /IM ' + (this.options.imageName || path.basename(this.cmd)); 
       debug('Executing shutdown taskkil', command);
       command = command.split(' ');
       execFile(command[0], command.slice(1)).once('exit', function(data) {

--- a/lib/local/instance.js
+++ b/lib/local/instance.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var spawn = require("child_process").spawn;
 var exec = require("child_process").exec;
+var execFile = require("child_process").execFile;
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('launchpad:local:instance');
 var rimraf = require('rimraf');
@@ -99,11 +100,14 @@ Instance.prototype.stop = function (callback) {
     if (this.options.command.indexOf('open') === 0) {
       command = 'osascript -e \'tell application "' + safe(self.options.process) + '" to quit\'';
       debug('Executing shutdown AppleScript', command);
-      exec(command);
+      command = command.split(' ');
+      execFile(command[0], command.slice(1));
     } else if (process.platform === 'win32') {
-      command = 'taskkill /IM "' + safe(this.options.imageName || path.basename(this.cmd)) + '"';
+      //Adding `"` wasn't safe/functional on Win systems
+      command = 'taskkill /IM ' + (this.options.imageName || path.basename(this.cmd); 
       debug('Executing shutdown taskkil', command);
-      exec(command).once('exit', function(data) {
+      command = command.split(' ');
+      execFile(command[0], command.slice(1)).once('exit', function(data) {
         self.emit('stop', data);
       });
     } else {

--- a/lib/local/instance.js
+++ b/lib/local/instance.js
@@ -5,7 +5,14 @@ var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('launchpad:local:instance');
 var rimraf = require('rimraf');
 
+var safe = function (str) {
+   // Avoid quotes makes impossible escape the `multi command` scenario
+   return str.replace(/['"]+/g, '');
+}
+
 var getProcessId = function (name, callback) {
+
+  name = safe(name);
 
   var commands = {
     darwin: "ps -clx | grep '" + name + "$' | awk '{print $2}' | head -1",
@@ -90,11 +97,11 @@ Instance.prototype.stop = function (callback) {
     } catch (error) {}
   } else {
     if (this.options.command.indexOf('open') === 0) {
-      command = 'osascript -e \'tell application "' + self.options.process + '" to quit\'';
+      command = 'osascript -e \'tell application "' + safe(self.options.process) + '" to quit\'';
       debug('Executing shutdown AppleScript', command);
       exec(command);
     } else if (process.platform === 'win32') {
-      command = 'taskkill /IM ' + (this.options.imageName || path.basename(this.cmd));
+      command = 'taskkill /IM "' + safe(this.options.imageName || path.basename(this.cmd)) + '"';
       debug('Executing shutdown taskkil', command);
       exec(command).once('exit', function(data) {
         self.emit('stop', data);

--- a/lib/local/version.js
+++ b/lib/local/version.js
@@ -6,6 +6,7 @@ var plist = require('plist');
 var utils = require('./utils');
 var debug = require('debug')('launchpad:local:version');
 
+// Validate paths supplied by the user in order to avoid "arbitrary command execution"
 var validPath = function (filename){
   var filter = /[`!@#$%^&*()_+\-=\[\]{};':"\\|,<>\/?~]/;
   if (filter.test(filename)){

--- a/lib/local/version.js
+++ b/lib/local/version.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var Q = require('q');
 var path = require('path');
 var plist = require('plist');
@@ -8,7 +9,7 @@ var debug = require('debug')('launchpad:local:version');
 
 // Validate paths supplied by the user in order to avoid "arbitrary command execution"
 var validPath = function (filename){
-  var filter = /[`!@#$%^&*()_+\-=\[\]{};':"\\|,<>\/?~]/;
+  var filter = /[`!@#$%^&*()_+\-=\[\]{};':"|,<>?~]/;
   if (filter.test(filename)){
     console.log('\nInvalid characters inside the path to the browser\n');
     return
@@ -28,7 +29,7 @@ module.exports = function(browser) {
 
     debug('Retrieving version for windows executable', command);
     // Can't use Q.nfcall here unfortunately because of non 0 exit code
-    exec(command.split(' ')[0], command.split(' ').slice(1), function(error, stdout) {
+    execFile(command.split(' ')[0], command.split(' ').slice(1), function(error, stdout) {
       var regex = /ProductVersion:\s*(.*)/;
       // ShowVer.exe returns a non zero status code even if it works
       if (typeof stdout === 'string' && regex.test(stdout)) {

--- a/lib/local/version.js
+++ b/lib/local/version.js
@@ -9,7 +9,7 @@ var debug = require('debug')('launchpad:local:version');
 
 // Validate paths supplied by the user in order to avoid "arbitrary command execution"
 var validPath = function (filename){
-  var filter = /[`!@#$%^&*()_+\-=\[\]{};':"|,<>?~]/;
+  var filter = /[`!@#$%^&*()_+\-=\[\]{};'"|,<>?~]/;
   if (filter.test(filename)){
     console.log('\nInvalid characters inside the path to the browser\n');
     return

--- a/lib/local/version.js
+++ b/lib/local/version.js
@@ -6,6 +6,15 @@ var plist = require('plist');
 var utils = require('./utils');
 var debug = require('debug')('launchpad:local:version');
 
+var validPath = function (filename){
+  var filter = /[`!@#$%^&*()_+\-=\[\]{};':"\\|,<>\/?~]/;
+  if (filter.test(filename)){
+    console.log('\nInvalid characters inside the path to the browser\n');
+    return
+  }
+  return filename;
+}
+
 module.exports = function(browser) {
   if (!browser || !browser.path) {
     return Q(null);
@@ -18,7 +27,7 @@ module.exports = function(browser) {
 
     debug('Retrieving version for windows executable', command);
     // Can't use Q.nfcall here unfortunately because of non 0 exit code
-    exec(command, function(error, stdout) {
+    exec(command.split(' ')[0], command.split(' ').slice(1), function(error, stdout) {
       var regex = /ProductVersion:\s*(.*)/;
       // ShowVer.exe returns a non zero status code even if it works
       if (typeof stdout === 'string' && regex.test(stdout)) {
@@ -47,8 +56,8 @@ module.exports = function(browser) {
   }
 
   // Try executing <browser> --version (everything else)
-  return Q.nfcall(exec, browser.path + ' --version').then(function(stdout) {
-    debug('Ran ' + browser.path + ' --version', stdout);
+  return Q.nfcall(exec, validPath(browser.path) + ' --version').then(function(stdout) {
+    debug('Ran ' + validPath(browser.path) + ' --version', stdout);
     var version = utils.getStdout(stdout);
     if (version) {
       browser.version = version;


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/app/bounties/open/1-npm-launchpad

### ⚙️ Description *

The issue arised in multiple locations, so I to validate the type of data the functions were going to use (like the `paths`) and since there were some `multi commands` I didn't use the `execFile` function, which should have had stored many new variables because we wouldn't have been to concatenate and return results that would have been used in a second/third command correlated to the first one executed. In this case I simply made a functionality that `deletes every quote` from the variable, making impossible threat the `variables concatenated` as commands, but only as `arguments` of the specific command.

### 💻 Technical Description *

The fix has been applied in 3 different ways inside 3 different files, so I'll comment each one.

1. The issue arises firstly here: https://github.com/bitovi/launchpad/blob/master/lib/local/instance.js#L12 because of the fact the `name` variable is `concatenated` inside the various commands without being sanitized. Since the `name` is inside some `single-quotes` it would have been useless split the 3 different commands inside 3 different `execFile` that would have used more resources to store the content of the singular commands that should be concatenated again ... instead I introduced the `safe` function which deletes the `quotes` from the `name` in order to make it to be only an argument not escapable from quotes. 

```js
var safe = function (str) {
   // Avoid quotes makes impossible escape the `multi command` scenario
   return str.replace(/['"]+/g, '');
}
```
Note I've used the `execFile` function later in this file in the following lines: https://github.com/Mik317/launchpad/blob/master/lib/local/instance.js#L104 and https://github.com/Mik317/launchpad/blob/master/lib/local/instance.js#L110, in order to avoid `commands` could be executed in a dangerous context.
2. The 2' issue arised inside the following line: https://github.com/bitovi/launchpad/blob/master/lib/local/version.js#L21
In this case it I used `execFile` in order to avoid concatenation of other strings containing dangerous characters.
Patched with:

```js
    exec(command.split(' ')[0], command.split(' ').slice(1), function(error, stdout) {
```
In this case the first part of the `command` is taken as `command to execute` (surely a path since the `command` variable is made through 

```js
    var command = path.join('"' + __dirname, '..', '..', 'resources', 'ShowVer.exe" "' + browser.command + '"');
```
), while the second part are the `arguments`.

3. The last issue arised here: https://github.com/bitovi/launchpad/blob/master/lib/local/version.js#L50
In this case the `browser path and filename` weren't checked completely, and even if the execution of malicious code would have been possible only if the `default browser` of the victim has a badly crafted `filename`, I inserted a check to see if the `path+filename` pointing to the browser is a valid `path`.
The issue has been fixed through this function:

```js
// Validate paths supplied by the user in order to avoid "arbitrary command execution"
var validPath = function (filename){
  var filter = /[`!@#$%^&*()_+\-=\[\]{};':"\\|,<>\/?~]/;
  if (filter.test(filename)){
    console.log('\nInvalid characters inside the path to the browser\n');
    return
  }
  return filename;
}
```

### 🐛 Proof of Concept (PoC) *

1. Download the JS library (launchpad)
2. Go inside the path you downloaded it and make the following `poc.js` file:

```js
// poc.js
var launchpad = require("./launchpad/lib/local/instance");
var tst = new launchpad.Instance('t', {}, {}, {process:"s'; touch HACKED; # "});
tst.getPid(function(){});
```
3. Execute through `node poc.js`
4. The `HACKED` file will we created
![Screenshot from 2020-06-26 19-34-24](https://user-images.githubusercontent.com/33063403/85889295-7bc61c80-b7eb-11ea-9bed-f5aa3d1d2af7.png)


### 🔥 Proof of Fix (PoF) *

1. Download the fixed version
2. Use the same POC previously indexed
3. The `HACKED` file is NOT created anymore 
![Screenshot from 2020-06-26 19-52-10](https://user-images.githubusercontent.com/33063403/85889359-98faeb00-b7eb-11ea-924b-7dc4b416753e.png)

### 👍 User Acceptance Testing (UAT)

It doesn't introduce any error (at least using the module through the PoC I crafted)

Regards, 
Mik